### PR TITLE
Fix Streamlit badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # :writing_hand: Hand writing generation
-[![Streamlit App](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://hand-writing-generation.streamlit.app/)
+[![Streamlit App](https://img.shields.io/badge/Streamlit-App-FF4B4B?logo=streamlit&logoColor=white)](https://hand-writing-generation.streamlit.app/)
 
 The objective of this project is to be able to:
 1. Classify hand-written characters

--- a/dashboard.py
+++ b/dashboard.py
@@ -9,7 +9,7 @@ from training.utils import class_num_to_label, generate_images, label_to_class_n
 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
-st.set_page_config("Hand-writing generator", page_icon="writing_hand", layout="wide")
+st.set_page_config("Hand-writing generator", page_icon="✍️", layout="wide")
 
 
 @st.cache_resource()


### PR DESCRIPTION
## Summary
- Replace the broken `static.streamlit.io` badge SVG with a working `shields.io` badge using the standard Streamlit red colour and logo
- Fix Streamlit favicon to use the ✍️ writing hand emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)